### PR TITLE
change auth level from anonymous to function

### DIFF
--- a/UrlRedirect.cs
+++ b/UrlRedirect.cs
@@ -22,7 +22,7 @@ namespace Cloud5mins.Function
 
         [Function("UrlRedirect")]
         public async Task<HttpResponseData> Run(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "urlredirect/{shortUrl}")]
+            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "urlredirect/{shortUrl}")]
             HttpRequestData req,
             string shortUrl,
             ExecutionContext context)


### PR DESCRIPTION
This PR changes the authorization level for the UrlRedirect function to Function. This requires that the Function Access Key be passed in the request header to authorize the action.

This function will only be called by the Azure API Management resource, which I have added the Function Access Key to.