### PR TITLE
Convert workflow runner to ubuntu

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -1,4 +1,4 @@
-name: Deploy DotNet project to Azure Function App
+name: Deploy DotNet project to Azure Function App dev
 
 on:
   push:
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     environment: dev
     steps:
       - name: "Checkout GitHub Action"

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,4 +1,4 @@
-name: Deploy DotNet project to Azure Function App
+name: Deploy DotNet project to Azure Function App prod
 
 on:
   release:
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     environment: prod
     steps:
       - name: "Checkout GitHub Action"

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -6,14 +6,14 @@ on:
   workflow_dispatch:
 
 env:
-  AZURE_FUNCTIONAPP_NAME: "Dev-STORIS-URL-Redirect"
+  AZURE_FUNCTIONAPP_NAME: "Prod-STORIS-URL-Redirect"
   AZURE_FUNCTIONAPP_PACKAGE_PATH: "."
   DOTNET_VERSION: "6.0.x"
 
 jobs:
   build-and-deploy:
     runs-on: windows-latest
-    environment: dev
+    environment: prod
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,0 +1,43 @@
+name: Deploy DotNet project to Azure Function App
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  AZURE_FUNCTIONAPP_NAME: "Dev-STORIS-URL-Redirect"
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: "."
+  DOTNET_VERSION: "6.0.x"
+
+jobs:
+  build-and-deploy:
+    runs-on: windows-latest
+    environment: dev
+    steps:
+      - name: "Checkout GitHub Action"
+        uses: actions/checkout@v3
+
+      - name: "Login via Azure CLI"
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_RBAC_CREDENTIALS_PROD }}
+
+      - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: "Resolve Project Dependencies Using Dotnet"
+        shell: pwsh
+        run: |
+          pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
+          dotnet build --configuration Release --output ./output
+          popd
+
+      - name: "Run Azure Functions Action"
+        uses: Azure/functions-action@v1
+        id: fa
+        with:
+          app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+          package: "${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/output"


### PR DESCRIPTION
This PR renames the deploy workflows for better differentiation and converts the runners to Ubuntu. There is currently an open issue with the .Net SDK included in the Windows runner that is fixed in the Ubuntu runner, [dotnet sdk 7.0.200 breaking change in latest runner](https://github.com/actions/runner-images/issues/7215). This is causing deployments to fail regardless of the SDK targeted, as it will use the latest SDK with this version.